### PR TITLE
:dizzy: Test emoji reactions with conda-lock-refresh GitHub Action

### DIFF
--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
-          # token: ${{ steps.generate-token.outputs.token }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,3 +4,4 @@ channels:
   - nodefaults
 dependencies:
   - jupyterlab~=4.0.0
+  - python~=3.11


### PR DESCRIPTION
Add a new dependency to environment.yml, and see if the conda-lock-refresh GitHub Action is triggered when a comment containing `/condalock` is made. Mainly testing that the emoji reactions :eyes:, :rocket:, :tada: will be displayed.
