### PR TITLE
:egg: Add emoji reactions on each step of the conda-lock action

### DIFF
--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -4,7 +4,7 @@ name: Conda Lock
 
 on:
   issue_comment:
-    types: [created, edited]
+    types: [created]
 
 permissions:
   contents: read
@@ -22,6 +22,14 @@ jobs:
         shell: bash -l {0}
 
     steps:
+      # Add an emoji reaction to comment to indicate the script is starting
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.comment.id }}
+          reaction-type: eyes
+
       # Checkout the pull request branch
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -29,6 +37,14 @@ jobs:
           # token: ${{ steps.generate-token.outputs.token }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
+
+      # Add an emoji reaction to comment to indicate that conda-lock is starting
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.comment.id }}
+          reaction-type: rocket
 
       # Run conda-lock GitHub Action
       - name: Run conda-lock
@@ -39,8 +55,8 @@ jobs:
 
       # Add an emoji reaction to comment to indicate the script completed successfully
       - name: Add reaction
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v3
         with:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          comment-id: ${{ github.event.comment.id }}
           reaction-type: hooray


### PR DESCRIPTION
Add :eyes: when on starting the GitHub Action, :rocket: when the conda-lock command is starting up, and :tada: when the conda-lock script finishes. Also updated peter-evans/create-or-update-comment from v2 to v3, and trigger the workflow only on issue comment creation, not edits.

Edit: Have patched this in 31e6812cae05b6715931ec6bf02c2137ee74f038, 99999b0b08220add8b5cab0dff8712aeb98243fc, and 20519fb7ed635ca884321352908150ac20fa6329 to work properly.