### PR TITLE
:necktie: Run workflow on PR comments that starts with /condalock

### DIFF
--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   condalock:
     # Only run on Pull Requests, when a comment with '/condalock' is made
-    if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '/condalock')
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/condalock')
     permissions:
       contents: write  # to git push added/changed files
       pull-requests: write  # for adding reactions to pull request comments


### PR DESCRIPTION
Fix the conditional logic so that the condalock job only runs on Pull Request comments that specifically starts with /condalock. Should fix issue mentioned at https://github.com/weiji14/conda-lock-refresh-demo/pull/2#issuecomment-1690972480.

References:
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only
- https://docs.github.com/en/actions/learn-github-actions/expressions#operators
- https://docs.github.com/en/actions/learn-github-actions/expressions#startswith