### PR TITLE
:alembic: Test condalock trigger and set actions/checkout to use github.ref_name

### DIFF
--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+          ref: ${{ github.ref_name }}
 
       # Add an emoji reaction to comment to indicate that conda-lock is starting
       - name: Add reaction

--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,4 @@ channels:
 dependencies:
   - jupyterlab~=4.0.0
   - python~=3.11
+  - pip~=23.2.1


### PR DESCRIPTION
Checking that the conda-lock-refresh GitHub Action is only triggered on Pull Request comments that starts with /condalock. I.e. the conditional logic at https://github.com/weiji14/conda-lock-refresh-demo/pull/4 is sound.

~Also switching from `github.event.client_payload.pull_request.head.ref` to `github.ref_name` in the actions/checkout step, to see if it's possible to push to the PR branch instead of the main branch. Xref https://docs.github.com/en/actions/learn-github-actions/contexts#github-context~ Edit: nope, doesn't work, see https://github.com/weiji14/conda-lock-refresh-demo/pull/5#discussion_r1303843926